### PR TITLE
Deprecate zope.app.broken.interfaces.IBroken.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Deprecate ``zope.app.broken.interfaces.IBroken``. Please import it directly
+  from ``ZODB.interfaces``.
 
 
 4.1 (2020-03-31)

--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,13 @@ setup(name='zope.app.broken',
       namespace_packages=['zope', 'zope.app'],
       install_requires=[
           'setuptools',
+          'zope.deferredimport',
           'zope.interface',
           'zope.location',
           'zope.security',
           'zope.annotation',
           'zope.processlifetime',
-          'ZODB',
+          'ZODB >= 3.10.0a1',
       ],
       extras_require={
           'test': [

--- a/src/zope/app/broken/interfaces.py
+++ b/src/zope/app/broken/interfaces.py
@@ -14,8 +14,11 @@
 """zope.app.broken interfaces.
 """
 
-__docformat__ = "reStructuredText"
+from zope.deferredimport import deprecated
 
-from ZODB.interfaces import IBroken
-
-__all__ = ["IBroken"]
+# BBB zope.app.broken 5.0: Names now moved to ZODB itself.
+deprecated(
+    'Please import from ZODB.interfaces.'
+    ' This module will go away in zope.app.broken 5.0.',
+    IBroken='ZODB.interfaces:IBroken',
+)


### PR DESCRIPTION
Please import it directly from ZODB.interfaces.

I implemented it as suggested in #4.