### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 6.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  CHANGES
 =========
 
-5.2 (unreleased)
+6.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -62,9 +61,6 @@ setup(name='zope.app.broken',
       ],
       url='http://github.com/zopefoundation/zope.app.broken',
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope', 'zope.app'],
       python_requires='>=3.9',
       install_requires=[
           'setuptools',
@@ -83,7 +79,7 @@ setup(name='zope.app.broken',
               'zope.browserresource',
               'zope.configuration',
               'zope.testing',
-              'zope.testrunner',
+              'zope.testrunner >= 6.4',
           ],
           'browser': [
               'zope.browsermenu',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def read(*rnames):
 
 
 setup(name='zope.app.broken',
-      version='5.2.dev0',
+      version='6.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.dev',
       description='Zope Broken (ZODB) Object Support',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: nocover

--- a/src/zope/app/__init__.py
+++ b/src/zope/app/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: nocover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
